### PR TITLE
Fix GIF panel bug

### DIFF
--- a/src/Pages/main.js
+++ b/src/Pages/main.js
@@ -159,6 +159,12 @@ function MessageSender() {
       sendButton.current.disabled = true;
     }
   }, [conversation_id]);
+
+  function handle_gif_panel() {
+    if (conversation_id) {
+      setShowGifSelector(!showGifSelector);
+    }
+  }
   
   return (
     <div className="messageSender">
@@ -166,7 +172,7 @@ function MessageSender() {
       <div className='message-box'>
         <textarea ref={messageBox} placeholder="Send a Message" onKeyDown={handle_send} id='message-box'rows="1" />
         <button className='gif-selector-button'>
-          <span onClick={() => setShowGifSelector(!showGifSelector)}>GIF</span>
+          <span onClick={handle_gif_panel}>GIF</span>
           <GifSelector showGifSelector={showGifSelector} setShowGifSelector={setShowGifSelector} />
         </button>
         <button title='Self-Destruct Message'>


### PR DESCRIPTION
## Description
Fixed a bug with the GIF panel where if the user tries to send a GIF without having a conversation selected it would throw an error causing it to go into a error loop.

## Related Issue
#129 

## Proposed Changes
To fix the issue, the GIF panel can no longer be opened if there is no conversation selected.

## Checklist
- [x] I have tested the changes locally.
- [x] I have updated the documentation (if necessary).
- [x] I have reviewed the code for any potential issues.
