### PR TITLE
142 add support for chunk loading system on client

### DIFF
--- a/src/components/main/go_to_recent.js
+++ b/src/components/main/go_to_recent.js
@@ -1,0 +1,37 @@
+import { useEffect, useState } from "react"
+
+export default function ReturnToRecent({ messages_container }) {
+    const [showButton, setShowButton] = useState(false);
+
+    useEffect(() => {
+        function handle_button_toggle() {
+            const scrollBottom = messages_container.current.scrollHeight - messages_container.current.scrollTop - messages_container.current.clientHeight;
+
+            if (scrollBottom >= 4000) {
+                setShowButton(true);
+            } else {
+                setShowButton(false);
+            }
+        }
+
+        if (messages_container.current) {
+            messages_container.current.addEventListener("scroll", handle_button_toggle);
+        }
+        
+        return () => {
+            if (messages_container.current) {
+                messages_container.current.removeEventListener("scroll", handle_button_toggle);    
+            }
+        }
+    }, [messages_container]);
+
+    function reset_scroll() {
+        messages_container.current.scrollTop = messages_container.current.scrollHeight;
+    }
+
+    if (showButton) {
+        return (
+            <button onClick={reset_scroll} className="return-to-recent-button">Jump To Recent</button>
+        );
+    }
+}

--- a/src/components/main/go_to_recent.js
+++ b/src/components/main/go_to_recent.js
@@ -20,10 +20,11 @@ export default function ReturnToRecent({ messages_container }) {
         
         return () => {
             if (messages_container.current) {
+                console.log("added messages scroll event listerner")
                 messages_container.current.removeEventListener("scroll", handle_button_toggle);    
             }
         }
-    }, [messages_container]);
+    }, [messages_container.current]);
 
     function reset_scroll() {
         messages_container.current.scrollTop = messages_container.current.scrollHeight;

--- a/src/components/main/messages.js
+++ b/src/components/main/messages.js
@@ -6,6 +6,8 @@ import connectSocket from "../../Scripts/mainPage/notification_conn_handler";
 import UnfriendUser from "./unfriend_user";
 import Clock from '../../assets/home/clock_icon.png';
 import GIPHY_LOGO from '../../assets/home/GIPHY_attrabution.png';
+import Spinner from '../../assets/global/loaders/loader-1.svg';
+import ReturnToRecent from "./go_to_recent";
 
 export default function Messages({ friendsListState, setFriendsListState }) {
     const [messages, setMessages] = useState('loading');
@@ -14,6 +16,12 @@ export default function Messages({ friendsListState, setFriendsListState }) {
     const [popupUsername, setPopupUsername] = useState();
     const [checkLinkPopup, setCheckLinkPopup] = useState(false);
     const [conversationName, setConversationName] = useState();
+    const [isLoadingAdditionalMessages, setIsLoadingAdditionalMessages] = useState(false);
+    const loadAdditionalMessages = useRef(false);
+    const initialLoad = useRef(true);
+    const messages_container = useRef();
+    const reset_scroll = useRef(true);
+    const previous_scroll_position = useRef();
 
     const { conversation_id } = useParams();
   
@@ -33,12 +41,31 @@ export default function Messages({ friendsListState, setFriendsListState }) {
       if (messages !== "loading" && messages !== false) {
         messagesRef.current = messages;
         console.log("Updated Messages: ", messagesRef.current);
-        console.log(typeof messages)
   
         // Scroll to the bottom of the message
         let messages_div = document.getElementById("message-container");
-        if (messages_div) {
+        if (messages_div && reset_scroll.current) {
           messages_div.scrollTop = messages_div.scrollHeight;
+        } else {
+          reset_scroll.current = true;
+
+          // Keep scroll position the same if reset scroll is false
+          if (previous_scroll_position.current && messages_div) {
+            const new_scroll_position = messages_div.scrollHeight - previous_scroll_position.current - 100;
+            messages_div.scrollTop = new_scroll_position;
+          }
+        }
+
+        console.log(messages.length);
+
+        if (initialLoad.current) {
+          if (messages.length >= 20) {
+            loadAdditionalMessages.current = true;
+          } else {
+            loadAdditionalMessages.current = false;
+          }
+
+          initialLoad.current = false;
         }
       }
     }, [messages]);
@@ -46,6 +73,9 @@ export default function Messages({ friendsListState, setFriendsListState }) {
     useEffect(() => {
       conversationIdRef.current = conversation_id;
       console.log("Updated conversation id: ", conversationIdRef.current);
+
+      // Reset initial load for next conversation
+      initialLoad.current = true;
     }, [conversation_id])
   
     // Start websocket connection to notification server
@@ -88,11 +118,14 @@ export default function Messages({ friendsListState, setFriendsListState }) {
         // Get auth data
         const username = localStorage.getItem('username');
         const token = localStorage.getItem('token');
+
+        // Reset additional message loader
+        setIsLoadingAdditionalMessages(false);
   
         // Change the message container to loading
         setMessages('loading');
   
-        fetch(`${process.env.REACT_APP_RINGER_SERVER_URL}/load_messages/${conversation_id}`, {
+        fetch(`${process.env.REACT_APP_RINGER_SERVER_URL}/load_messages/${conversation_id}?offset=0`, {
           headers: {
             username: username,
             token: token,
@@ -155,6 +188,62 @@ export default function Messages({ friendsListState, setFriendsListState }) {
         }
       });
     };
+
+    useEffect(() => {
+      if (messages !== 'loading' && messages !== null) {
+        const messages_container = document.getElementById('message-container');
+
+        const handleScrollEnd = () => {
+          const scrollPosition = messages_container.scrollTop;
+          console.log("load more messages: " + loadAdditionalMessages.current)
+          if (scrollPosition === 0 && loadAdditionalMessages && loadAdditionalMessages.current) {
+              previous_scroll_position.current = messages_container.scrollHeight;
+
+              setIsLoadingAdditionalMessages(true);
+
+              // Make a copy of messages to work with
+              let new_messages = [...messages]
+
+              fetch(`${process.env.REACT_APP_RINGER_SERVER_URL}/load_messages/${conversationIdRef.current}?offset=${messages.length}`, {
+                headers: {
+                  username: localStorage.getItem('username'),
+                  token: localStorage.getItem('token')
+                }
+              })
+              .then((response) => {
+                if (response.ok) {
+                  return response.json();
+                } else {
+                  throw new Error('Request failed with status code: ' + response.status);
+                }
+              })
+              .then((data) => {
+                setIsLoadingAdditionalMessages(false);
+
+                // Disable scroll reset during the loading of additional messages
+                reset_scroll.current = false;
+
+                new_messages.unshift(...data);
+                setMessages(new_messages);
+
+                if (data.length < 20) {
+                  loadAdditionalMessages.current = false;
+                }
+              })
+              .catch((error) => {
+                setIsLoadingAdditionalMessages(false);
+                console.error(error);
+              })
+          }
+        };
+      
+        messages_container.addEventListener('scrollend', handleScrollEnd);
+
+        return () => {
+          messages_container.removeEventListener('scrollend', handleScrollEnd);
+        }
+      }
+    }, [messages]);
   
     return (
       <div className="messages">
@@ -197,7 +286,10 @@ export default function Messages({ friendsListState, setFriendsListState }) {
           </div>
         ) : (
           typeof messages === 'object' && messages !== null ? (
-            <div className='message-container' id='message-container'>
+            <div className='message-container' id='message-container' ref={messages_container}>
+              {isLoadingAdditionalMessages ? (
+                <img src={Spinner} />
+              ): null}
               {messages.map((message, index) => (
                 <div key={index} className='message'>
                   <img src={`${process.env.REACT_APP_LIF_AUTH_SERVER_URL}/get_pfp/${message.Author}.png`} alt='' onClick={() => handle_open_popup(message.Author)} />
@@ -232,6 +324,7 @@ export default function Messages({ friendsListState, setFriendsListState }) {
             <h1>Nothing to see here...</h1>
           )
         )}
+        <ReturnToRecent messages_container={messages_container} />
         <UnfriendUser 
           unfriendState={unfriendState}
           setUnfriendState={setUnfriendState}

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -1435,3 +1435,27 @@ input[type="search"]::-webkit-search-cancel-button {
 .giphy-logo:hover {
     transform: scale(1) !important;
 }
+
+@keyframes return-to-recent-animation {
+    0% {
+        opacity: 0;
+        bottom: 80px;
+    } 
+    100% {
+        opacity: 1;
+        bottom: 100px;
+    }
+}
+
+.return-to-recent-button {
+    background-color: #545454;
+    border: none;
+    border-radius: 0.5em;
+    padding: 10px;
+    color: white;
+    position: absolute;
+    right: 50px;
+    bottom: 100px;
+    cursor: pointer;
+    animation: return-to-recent-animation 0.2s ease-in-out;
+}


### PR DESCRIPTION
## Description
Added a feature for users to load previous messages in the conversation by scrolling up.

## Related Issue
#142 

## Proposed Changes
When the client loads a conversation, it loads the last 20 messages. The user can load more by scrolling up. When they scroll far enough they can click a button and jump back to the most recent messages.

## Checklist
- [x] I have tested the changes locally.
- [x] I have updated the documentation (if necessary).
- [x] I have reviewed the code for any potential issues.
