### PR TITLE
Fix scrolling bug

### DIFF
--- a/src/components/main/messages.js
+++ b/src/components/main/messages.js
@@ -242,6 +242,15 @@ export default function Messages({ friendsListState, setFriendsListState }) {
         }
       }
     }, [messages]);
+
+    // Moves the scroll position down by the hight of the image
+    const handleGIFLoad = (event) => {
+      const imageHeight = event.target.height;
+
+      if (messages_container.current && initialLoad.current) {
+        messages_container.current.scrollTop = messages_container.current.scrollTop + imageHeight;
+      }
+    };
   
     return (
       <div className="messages">
@@ -298,7 +307,7 @@ export default function Messages({ friendsListState, setFriendsListState }) {
                     </div>
                     {message.Message_Type === "GIF" ? (
                       <>
-                        <img className="message-gif" src={message.GIF_URL} alt={message.Message} />
+                        <img onLoad={handleGIFLoad} className="message-gif" src={message.GIF_URL} alt={message.Message} />
                         <img className="giphy-logo" src={GIPHY_LOGO} />
                       </>
                     ) : (


### PR DESCRIPTION
## Description
Fixed an issue with the conversation loading when upon initial load if there were GIFs in the conversation then the conversation would not be scrolled all the way to the bottom.

## Related Issue
#132 

## Proposed Changes
Ringer now upon initial load of a conversation will move the scroll the chat down by the hight of the GIF being loaded.

## Checklist
- [x] I have tested the changes locally.
- [x] I have updated the documentation (if necessary).
- [x] I have reviewed the code for any potential issues.
