### PR TITLE
Add client-side notifications

### DIFF
--- a/main.js
+++ b/main.js
@@ -3,6 +3,7 @@ const {app, BrowserWindow, shell, ipcMain} = require('electron');
 const path = require('path');
 const { autoUpdater } = require('electron-updater');
 require('dotenv').config();
+const { Notification } = require('electron')
 
 autoUpdater.autoDownload = true;
 autoUpdater.autoInstallOnAppQuit = true;
@@ -50,6 +51,15 @@ function createWindow () {
   ipcMain.on('open-url', (event, url) => {
     console.log('opening ' + url);
     shell.openExternal(url);
+  })
+
+  ipcMain.on('send-notification', (event, title, description) => {
+    console.log('sending notification');
+    const myNotification = new Notification({ 
+        title: title, 
+        body: description 
+    });
+    myNotification.show();
   })
 
   // Remove the menu bar from the main window

--- a/preload.js
+++ b/preload.js
@@ -3,7 +3,8 @@ const { contextBridge, ipcRenderer } = require('electron/renderer')
 // Allow render process to open external links
 contextBridge.exposeInMainWorld('electronAPI', {
   openURL: (url) => ipcRenderer.send('open-url', url),
-  restartApp: () => ipcRenderer.send('restart-app')
+  restartApp: () => ipcRenderer.send('restart-app'),
+  sendNotification: (title, description) => ipcRenderer.send('send-notification', title, description)
 })
 
 contextBridge.exposeInMainWorld('electron', {

--- a/src/Scripts/mainPage/notification_conn_handler.js
+++ b/src/Scripts/mainPage/notification_conn_handler.js
@@ -50,6 +50,15 @@ async function connectSocket(conversationIdRef, messagesRef, update_messages) {
                         }
                     });
                     document.dispatchEvent(message_update_event);
+
+                    // Get current logged in user
+                    const current_user = localStorage.getItem('username');
+
+                    // Only send notification if user is not the current logged in user and
+                    // only if the user is not active inside the window
+                    if (!document.hasFocus() && current_user !== server_data.Message.Author) {
+                        window.electronAPI.sendNotification(server_data.Message.Author, server_data.Message.Message);
+                    }
                 } else {
                     console.log("Received message! Conversation Not Selected");
                 }


### PR DESCRIPTION
## Description
Added support for client-side notifications.

## Related Issue
#152 

## Proposed Changes
When the user receives a message and they are not focused in the window they will receive a notification on their desktop.

## Checklist
- [x] I have tested the changes locally.
- [x] I have updated the documentation (if necessary).
- [x] I have reviewed the code for any potential issues.
