### PR TITLE
Fix friend request deny bug

### DIFF
--- a/src/components/main/friend_request.js
+++ b/src/components/main/friend_request.js
@@ -52,7 +52,12 @@ export default function FriendRequest({sender, id, remove_request}) {
                     user_online: data.sender_presence
                 }
             });
-            document.dispatchEvent(friend_request_accept_event);
+
+            // Check if "type" is "accept"
+            // If so then dispatch an event to update the friends list with the new conversation
+            if (type === "accept") {
+                document.dispatchEvent(friend_request_accept_event);
+            }
         })
         .catch((error) => {
             setIsLoading(false);


### PR DESCRIPTION
## Description
Fixed a bug where Ringer would add a non-existent conversation to the friends list when you denied a friend request.

## Related Issue
#174 

## Proposed Changes
The issue came down the the fact that the same function is used to accept and deny friend requests. The issue was that the function dispatched the friend request accept event regardless on the action being performed. A check was added so it only sends the event when the user accepts a friend request.

## Checklist
- [x] I have tested the changes locally.
- [x] I have updated the documentation (if necessary).
- [x] I have reviewed the code for any potential issues.