### PR TITLE
Fix view message bug.

### DIFF
--- a/src/Scripts/mainPage/notification_conn_handler.js
+++ b/src/Scripts/mainPage/notification_conn_handler.js
@@ -39,7 +39,7 @@ async function connectSocket(conversationIdRef, messagesRef, update_messages) {
                     // If the conversation that the message was sent in is selected,
                     // Tell the server that the message has been viewed
                     if (conversationIdRef.current === server_data.Id && username !== server_data.Message.Author) {
-                        socket.send(JSON.stringify({MessageType: "VIEW_MESSAGE", Message_Id: server_data.Message.Id, Conversation_Id: server_data.Id}));
+                        socket.send(JSON.stringify({MessageType: "VIEW_MESSAGE", Message_Id: server_data.Message.Message_Id, Conversation_Id: server_data.Id}));
                     }
 
                     // Admit an event to update the friends list


### PR DESCRIPTION
## Description
Fixes an issue with the view message request. Ringer was not sending the message id when making the request causing an error.

## Related Issue
#178 

## Proposed Changes
Updated Ringer to correctly send the message id when making the view message request.

## Checklist
- [x] I have tested the changes locally.
- [x] I have updated the documentation (if necessary).
- [x] I have reviewed the code for any potential issues.
